### PR TITLE
SHARD-2019 - Prettier lib-crypto-web

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+build
+node_modules
+dist
+target

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ build
 node_modules
 dist
 target
+bin

--- a/index.js
+++ b/index.js
@@ -4,14 +4,12 @@ const stringify = require('json-stable-stringify')
 let sodium
 let HASH_KEY
 
-function _throwUninitErr () {
-  throw new Error(
-    'Initialize function must be called before using other functions from this library.'
-  )
+function _throwUninitErr() {
+  throw new Error('Initialize function must be called before using other functions from this library.')
 }
 
 // Returns 32-bytes random hex string, otherwise the number of bytes can be specified as an integer
-function randomBytes (bytes = 32) {
+function randomBytes(bytes = 32) {
   if (!sodium) _throwUninitErr()
   if (!Number.isInteger(bytes) || bytes <= 0) {
     throw new TypeError('Bytes must be given as integer greater than zero.')
@@ -20,12 +18,10 @@ function randomBytes (bytes = 32) {
 }
 
 // Returns the Blake2b hash of the input string or Buffer, default output type is hex
-function hash (input, fmt = 'hex') {
+function hash(input, fmt = 'hex') {
   if (!sodium) _throwUninitErr()
   if (!HASH_KEY) {
-    throw new Error(
-      'Hash key must be passed to the initialize function before .'
-    )
+    throw new Error('Hash key must be passed to the initialize function before .')
   }
   if (typeof input !== 'string') {
     throw new TypeError('Input must be a string or buffer.')
@@ -47,20 +43,18 @@ function hash (input, fmt = 'hex') {
 }
 
 // Returns the hash of the provided object as a hex string, takes an optional second parameter to hash an object with the "sign" field
-function hashObj (obj, removeSign = false) {
+function hashObj(obj, removeSign = false) {
   if (typeof obj !== 'object') {
     throw TypeError('Input must be an object.')
   }
-  function performHash (obj) {
+  function performHash(obj) {
     let input = stringify(obj)
     let hashed = hash(input)
     return hashed
   }
   if (removeSign) {
     if (!obj.sign) {
-      throw Error(
-        'Object must contain a sign field if removeSign is flagged true.'
-      )
+      throw Error('Object must contain a sign field if removeSign is flagged true.')
     }
     let signObj = obj.sign
     delete obj.sign
@@ -72,7 +66,7 @@ function hashObj (obj, removeSign = false) {
   }
 }
 
-function encryptAB (input, pub, sec) {
+function encryptAB(input, pub, sec) {
   let inputBuf, pubBuf, secBuf, pubBoxBuf, secBoxBuf, nonce, encrypted
   if (!sodium) _throwUninitErr()
   if (typeof input !== 'string') {
@@ -103,7 +97,7 @@ function encryptAB (input, pub, sec) {
   return sodium.to_hex(nonce) + ':' + sodium.to_base64(encrypted)
 }
 
-function decryptAB (input, pub, sec) {
+function decryptAB(input, pub, sec) {
   let inputBuf, pubBuf, secBuf, pubBoxBuf, secBoxBuf, nonce, decrypted
   let nonceHex, inputBase64
 
@@ -116,9 +110,7 @@ function decryptAB (input, pub, sec) {
     nonce = sodium.from_hex(nonceHex)
     inputBuf = sodium.from_base64(inputBase64)
   } catch (e) {
-    throw new TypeError(
-      'Message to decrypt in must have nonce:ciphertext as hex:base64'
-    )
+    throw new TypeError('Message to decrypt in must have nonce:ciphertext as hex:base64')
   }
   try {
     pubBuf = sodium.from_hex(pub)
@@ -134,12 +126,7 @@ function decryptAB (input, pub, sec) {
   pubBoxBuf = sodium.crypto_sign_ed25519_pk_to_curve25519(pubBuf)
   secBoxBuf = sodium.crypto_sign_ed25519_sk_to_curve25519(secBuf)
   try {
-    decrypted = sodium.crypto_box_open_easy(
-      inputBuf,
-      nonce,
-      pubBoxBuf,
-      secBoxBuf
-    )
+    decrypted = sodium.crypto_box_open_easy(inputBuf, nonce, pubBoxBuf, secBoxBuf)
   } catch (e) {
     throw new TypeError('Could not decrypt the message')
   }
@@ -148,7 +135,7 @@ function decryptAB (input, pub, sec) {
 }
 
 // Generates and retuns {publicKey, secretKey} as hex strings
-function generateKeypair () {
+function generateKeypair() {
   let publicBox, privateBox
   if (!sodium) _throwUninitErr()
   let { publicKey, privateKey } = sodium.crypto_sign_keypair()
@@ -156,12 +143,12 @@ function generateKeypair () {
   // console.log('publicBox', publicBox)
   return {
     publicKey: sodium.to_hex(publicKey),
-    secretKey: sodium.to_hex(privateKey)
+    secretKey: sodium.to_hex(privateKey),
   }
 }
 
 // Returns a signature obtained by signing the input hash (hex string or buffer) with the sk string
-function sign (input, sk) {
+function sign(input, sk) {
   if (!sodium) _throwUninitErr()
   let inputBuf
   let skBuf
@@ -188,7 +175,7 @@ function sign (input, sk) {
   Attaches a sign field to the input object, containing a signed version
   of the hash of the object, along with the public key of the signer
 */
-function signObj (obj, sk, pk) {
+function signObj(obj, sk, pk) {
   if (typeof obj !== 'object') {
     throw new TypeError('Input must be an object.')
   }
@@ -205,7 +192,7 @@ function signObj (obj, sk, pk) {
 }
 
 // Returns true if the hash of the input was signed by the owner of the pk
-function verify (msg, sig, pk) {
+function verify(msg, sig, pk) {
   if (!sodium) _throwUninitErr()
   if (typeof msg !== 'string') {
     throw new TypeError('Message to compare must be a string.')
@@ -233,37 +220,29 @@ function verify (msg, sig, pk) {
     let verified = sodium.to_hex(sodium.crypto_sign_open(sigBuf, pkBuf))
     return verified === msg
   } catch (e) {
-    throw new Error(
-      'Unable to verify provided signature with provided public key.'
-    )
+    throw new Error('Unable to verify provided signature with provided public key.')
   }
 }
 
 // Returns true if the hash of the object minus the sign field matches the signed message in the sign field
-function verifyObj (obj) {
+function verifyObj(obj) {
   if (typeof obj !== 'object') {
     throw new TypeError('Input must be an object.')
   }
   if (!obj.sign || !obj.sign.owner || !obj.sign.sig) {
-    throw new Error(
-      'Object must contain a sign field with the following data: { owner, sig }'
-    )
+    throw new Error('Object must contain a sign field with the following data: { owner, sig }')
   }
   if (typeof obj.sign.owner !== 'string') {
-    throw new TypeError(
-      'Owner must be a public key represented as a hex string.'
-    )
+    throw new TypeError('Owner must be a public key represented as a hex string.')
   }
   if (typeof obj.sign.sig !== 'string') {
-    throw new TypeError(
-      'Signature must be a valid signature represented as a hex string.'
-    )
+    throw new TypeError('Signature must be a valid signature represented as a hex string.')
   }
   let objHash = hashObj(obj, true)
   return verify(objHash, obj.sign.sig, obj.sign.owner)
 }
 
-async function initialize (key) {
+async function initialize(key) {
   await _sodium.ready
   sodium = _sodium
   console.log(sodium)

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,4 +7,4 @@ module.exports = {
   coverageReporters: ['json', 'lcov', 'text', 'json-summary'],
   verbose: true,
   testTimeout: 10000, // Increased timeout for async operations
-}; 
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "release:prerelease": "npm run prepare && npm version prerelease --preid=prerelease && git push --follow-tags && npm publish --tag prerelease",
     "release:patch": "npm run prepare && npm version patch && git push --follow-tags && npm publish",
     "release:minor": "npm run prepare && npm version minor && git push --follow-tags && npm publish",
-    "release:major": "npm run prepare && npm version major && git push --follow-tags && npm publish"
+    "release:major": "npm run prepare && npm version major && git push --follow-tags && npm publish",
+    "format-check": "prettier --check \"**/*.{js,jsx,ts,tsx,json}\"",
+    "format-fix": "prettier --write \"**/*.{js,jsx,ts,tsx,json}\""
   },
   "repository": {
     "type": "git",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  singleQuote: true,
+  trailingComma: 'es5',
+  semi: false,
+  printWidth: 120,
+}

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
-const crypto = require('./index.js');
-(async () => {
+const crypto = require('./index.js')
+;(async () => {
   try {
     await crypto.initialize('69fa4195670576c0160d660c3be36556ff8d504725be8a59b5a96509e0c994bc')
     console.log(crypto.randomBytes())

--- a/test/unit/crypto.test.js
+++ b/test/unit/crypto.test.js
@@ -1,215 +1,207 @@
-const crypto = require("../../index.js");
+const crypto = require('../../index.js')
 
 // Test hash key for initialization
-const TEST_HASH_KEY =
-  "64f152869ca2d473e4ba64ab53f49ccdb2edae22da192c126850970e788af347";
+const TEST_HASH_KEY = '64f152869ca2d473e4ba64ab53f49ccdb2edae22da192c126850970e788af347'
 
 // Mock console.log to prevent output during tests
 beforeAll(() => {
-  jest.spyOn(console, "log").mockImplementation(() => {});
-  jest.spyOn(console, "warn").mockImplementation(() => {});
-  jest.spyOn(console, "error").mockImplementation(() => {});
-});
+  jest.spyOn(console, 'log').mockImplementation(() => {})
+  jest.spyOn(console, 'warn').mockImplementation(() => {})
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+})
 
 afterAll(() => {
-  jest.restoreAllMocks();
-});
+  jest.restoreAllMocks()
+})
 
-describe("Crypto Library", () => {
-  const testHashKey =
-    "69fa4195670576c0160d660c3be36556ff8d504725be8a59b5a96509e0c994bc";
+describe('Crypto Library', () => {
+  const testHashKey = '69fa4195670576c0160d660c3be36556ff8d504725be8a59b5a96509e0c994bc'
 
   // Initialize the library before all tests
   beforeAll(async () => {
-    await crypto.initialize(testHashKey);
-  });
+    await crypto.initialize(testHashKey)
+  })
 
-  describe("initialization", () => {
-    it("should initialize successfully with a valid hash key", async () => {
-      await expect(crypto.initialize(testHashKey)).resolves.not.toThrow();
-    });
+  describe('initialization', () => {
+    it('should initialize successfully with a valid hash key', async () => {
+      await expect(crypto.initialize(testHashKey)).resolves.not.toThrow()
+    })
 
-    it("should throw an error if hash key is invalid", async () => {
-      await expect(crypto.initialize("invalid")).rejects.toThrow();
-    });
-  });
+    it('should throw an error if hash key is invalid', async () => {
+      await expect(crypto.initialize('invalid')).rejects.toThrow()
+    })
+  })
 
-  describe("randomBytes", () => {
-    it("should generate random bytes of default length (32)", () => {
-      const bytes = crypto.randomBytes();
-      expect(bytes).toHaveLength(64); // 32 bytes in hex is 64 characters
-    });
+  describe('randomBytes', () => {
+    it('should generate random bytes of default length (32)', () => {
+      const bytes = crypto.randomBytes()
+      expect(bytes).toHaveLength(64) // 32 bytes in hex is 64 characters
+    })
 
-    it("should generate random bytes of specified length", () => {
-      const bytes = crypto.randomBytes(16);
-      expect(bytes).toHaveLength(32); // 16 bytes in hex is 32 characters
-    });
+    it('should generate random bytes of specified length', () => {
+      const bytes = crypto.randomBytes(16)
+      expect(bytes).toHaveLength(32) // 16 bytes in hex is 32 characters
+    })
 
-    it("should throw an error if bytes parameter is invalid", () => {
-      expect(() => crypto.randomBytes("invalid")).toThrow();
-    });
-  });
+    it('should throw an error if bytes parameter is invalid', () => {
+      expect(() => crypto.randomBytes('invalid')).toThrow()
+    })
+  })
 
-  describe("hash", () => {
-    it("should hash a string input and return a hex string by default", () => {
-      const hash = crypto.hash("test");
-      expect(typeof hash).toBe("string");
-      expect(hash).toMatch(/^[0-9a-f]{64}$/); // 32 bytes in hex is 64 characters
-    });
+  describe('hash', () => {
+    it('should hash a string input and return a hex string by default', () => {
+      const hash = crypto.hash('test')
+      expect(typeof hash).toBe('string')
+      expect(hash).toMatch(/^[0-9a-f]{64}$/) // 32 bytes in hex is 64 characters
+    })
 
-    it("should return consistent hash for the same input", () => {
-      const hash1 = crypto.hash("test");
-      const hash2 = crypto.hash("test");
-      expect(hash1).toBe(hash2);
-    });
+    it('should return consistent hash for the same input', () => {
+      const hash1 = crypto.hash('test')
+      const hash2 = crypto.hash('test')
+      expect(hash1).toBe(hash2)
+    })
 
-    it("should return different hashes for different inputs", () => {
-      const hash1 = crypto.hash("test1");
-      const hash2 = crypto.hash("test2");
-      expect(hash1).not.toBe(hash2);
-    });
+    it('should return different hashes for different inputs', () => {
+      const hash1 = crypto.hash('test1')
+      const hash2 = crypto.hash('test2')
+      expect(hash1).not.toBe(hash2)
+    })
 
-    it("should support uint8arr output format", () => {
-      const hash = crypto.hash("test", "uint8arr");
-      expect(hash).toBeInstanceOf(Uint8Array);
-      expect(hash.length).toBe(32); // 32 bytes
-    });
+    it('should support uint8arr output format', () => {
+      const hash = crypto.hash('test', 'uint8arr')
+      expect(hash).toBeInstanceOf(Uint8Array)
+      expect(hash.length).toBe(32) // 32 bytes
+    })
 
-    it("should throw an error for invalid input type", () => {
-      expect(() => crypto.hash(null)).toThrow();
-    });
+    it('should throw an error for invalid input type', () => {
+      expect(() => crypto.hash(null)).toThrow()
+    })
 
-    it("should throw an error for invalid output format", () => {
-      expect(() => crypto.hash("test", "invalid")).toThrow();
-    });
-  });
+    it('should throw an error for invalid output format', () => {
+      expect(() => crypto.hash('test', 'invalid')).toThrow()
+    })
+  })
 
-  describe("hashObj", () => {
-    it("should hash an object and return a hex string", () => {
-      const obj = { test: "value" };
-      const hash = crypto.hashObj(obj);
-      expect(typeof hash).toBe("string");
-      expect(hash).toMatch(/^[0-9a-f]{64}$/);
-    });
+  describe('hashObj', () => {
+    it('should hash an object and return a hex string', () => {
+      const obj = { test: 'value' }
+      const hash = crypto.hashObj(obj)
+      expect(typeof hash).toBe('string')
+      expect(hash).toMatch(/^[0-9a-f]{64}$/)
+    })
 
-    it("should return consistent hash for the same object", () => {
-      const obj = { test: "value" };
-      const hash1 = crypto.hashObj(obj);
-      const hash2 = crypto.hashObj(obj);
-      expect(hash1).toBe(hash2);
-    });
+    it('should return consistent hash for the same object', () => {
+      const obj = { test: 'value' }
+      const hash1 = crypto.hashObj(obj)
+      const hash2 = crypto.hashObj(obj)
+      expect(hash1).toBe(hash2)
+    })
 
-    it("should hash objects with properties in different order the same way", () => {
-      const obj1 = { a: 1, b: 2 };
-      const obj2 = { b: 2, a: 1 };
-      const hash1 = crypto.hashObj(obj1);
-      const hash2 = crypto.hashObj(obj2);
-      expect(hash1).toBe(hash2);
-    });
+    it('should hash objects with properties in different order the same way', () => {
+      const obj1 = { a: 1, b: 2 }
+      const obj2 = { b: 2, a: 1 }
+      const hash1 = crypto.hashObj(obj1)
+      const hash2 = crypto.hashObj(obj2)
+      expect(hash1).toBe(hash2)
+    })
 
-    it("should hash an object without the sign field when removeSign is true", () => {
-      const obj = { test: "value", sign: { owner: "test", sig: "test" } };
-      const hashWithSign = crypto.hashObj(obj, false);
-      const hashWithoutSign = crypto.hashObj(obj, true);
-      expect(hashWithSign).not.toBe(hashWithoutSign);
-    });
+    it('should hash an object without the sign field when removeSign is true', () => {
+      const obj = { test: 'value', sign: { owner: 'test', sig: 'test' } }
+      const hashWithSign = crypto.hashObj(obj, false)
+      const hashWithoutSign = crypto.hashObj(obj, true)
+      expect(hashWithSign).not.toBe(hashWithoutSign)
+    })
 
-    it("should throw an error for invalid input type", () => {
-      expect(() => crypto.hashObj("not an object")).toThrow();
-    });
+    it('should throw an error for invalid input type', () => {
+      expect(() => crypto.hashObj('not an object')).toThrow()
+    })
 
-    it("should throw an error when removeSign is true but object has no sign field", () => {
-      const obj = { test: "value" };
-      expect(() => crypto.hashObj(obj, true)).toThrow();
-    });
-  });
+    it('should throw an error when removeSign is true but object has no sign field', () => {
+      const obj = { test: 'value' }
+      expect(() => crypto.hashObj(obj, true)).toThrow()
+    })
+  })
 
-  describe("generateKeypair", () => {
-    it("should generate a keypair with publicKey and secretKey", () => {
-      const keypair = crypto.generateKeypair();
-      expect(keypair).toHaveProperty("publicKey");
-      expect(keypair).toHaveProperty("secretKey");
-      expect(keypair.publicKey).toMatch(/^[0-9a-f]{64}$/);
-      expect(keypair.secretKey).toMatch(/^[0-9a-f]{128}$/);
-    });
-  });
+  describe('generateKeypair', () => {
+    it('should generate a keypair with publicKey and secretKey', () => {
+      const keypair = crypto.generateKeypair()
+      expect(keypair).toHaveProperty('publicKey')
+      expect(keypair).toHaveProperty('secretKey')
+      expect(keypair.publicKey).toMatch(/^[0-9a-f]{64}$/)
+      expect(keypair.secretKey).toMatch(/^[0-9a-f]{128}$/)
+    })
+  })
 
-  describe("sign and verify", () => {
-    it("should sign a message hash and verify it successfully", () => {
-      const keypair = crypto.generateKeypair();
-      const message = "test message";
-      const messageHash = crypto.hash(message);
+  describe('sign and verify', () => {
+    it('should sign a message hash and verify it successfully', () => {
+      const keypair = crypto.generateKeypair()
+      const message = 'test message'
+      const messageHash = crypto.hash(message)
 
-      const signature = crypto.sign(messageHash, keypair.secretKey);
+      const signature = crypto.sign(messageHash, keypair.secretKey)
       // The signature length can vary, but it should be a hex string
-      expect(typeof signature).toBe("string");
-      expect(signature).toMatch(/^[0-9a-f]+$/);
+      expect(typeof signature).toBe('string')
+      expect(signature).toMatch(/^[0-9a-f]+$/)
 
-      const verified = crypto.verify(messageHash, signature, keypair.publicKey);
-      expect(verified).toBe(true);
-    });
+      const verified = crypto.verify(messageHash, signature, keypair.publicKey)
+      expect(verified).toBe(true)
+    })
 
-    it("should fail verification with incorrect message", () => {
-      const keypair = crypto.generateKeypair();
-      const message1 = "test message";
-      const message2 = "different message";
-      const messageHash1 = crypto.hash(message1);
-      const messageHash2 = crypto.hash(message2);
+    it('should fail verification with incorrect message', () => {
+      const keypair = crypto.generateKeypair()
+      const message1 = 'test message'
+      const message2 = 'different message'
+      const messageHash1 = crypto.hash(message1)
+      const messageHash2 = crypto.hash(message2)
 
-      const signature = crypto.sign(messageHash1, keypair.secretKey);
+      const signature = crypto.sign(messageHash1, keypair.secretKey)
 
       // The verify function returns false for incorrect messages
-      const verified = crypto.verify(
-        messageHash2,
-        signature,
-        keypair.publicKey
-      );
-      expect(verified).toBe(false);
-    });
+      const verified = crypto.verify(messageHash2, signature, keypair.publicKey)
+      expect(verified).toBe(false)
+    })
 
-    it("should fail verification with incorrect public key", () => {
-      const keypair1 = crypto.generateKeypair();
-      const keypair2 = crypto.generateKeypair();
-      const message = "test message";
-      const messageHash = crypto.hash(message);
+    it('should fail verification with incorrect public key', () => {
+      const keypair1 = crypto.generateKeypair()
+      const keypair2 = crypto.generateKeypair()
+      const message = 'test message'
+      const messageHash = crypto.hash(message)
 
-      const signature = crypto.sign(messageHash, keypair1.secretKey);
+      const signature = crypto.sign(messageHash, keypair1.secretKey)
 
       // The verify function throws an error when verification fails with wrong public key
       expect(() => {
-        crypto.verify(messageHash, signature, keypair2.publicKey);
-      }).toThrow(
-        "Unable to verify provided signature with provided public key"
-      );
-    });
-  });
+        crypto.verify(messageHash, signature, keypair2.publicKey)
+      }).toThrow('Unable to verify provided signature with provided public key')
+    })
+  })
 
-  describe("signObj and verifyObj", () => {
-    it("should sign an object and verify it successfully", () => {
-      const keypair = crypto.generateKeypair();
-      const obj = { test: "value" };
+  describe('signObj and verifyObj', () => {
+    it('should sign an object and verify it successfully', () => {
+      const keypair = crypto.generateKeypair()
+      const obj = { test: 'value' }
 
-      crypto.signObj(obj, keypair.secretKey, keypair.publicKey);
+      crypto.signObj(obj, keypair.secretKey, keypair.publicKey)
 
-      expect(obj).toHaveProperty("sign");
-      expect(obj.sign).toHaveProperty("owner");
-      expect(obj.sign).toHaveProperty("sig");
-      expect(obj.sign.owner).toBe(keypair.publicKey);
+      expect(obj).toHaveProperty('sign')
+      expect(obj.sign).toHaveProperty('owner')
+      expect(obj.sign).toHaveProperty('sig')
+      expect(obj.sign.owner).toBe(keypair.publicKey)
 
-      const verified = crypto.verifyObj(obj);
-      expect(verified).toBe(true);
-    });
+      const verified = crypto.verifyObj(obj)
+      expect(verified).toBe(true)
+    })
 
-    it("should fail verification if object is modified after signing", () => {
-      const keypair = crypto.generateKeypair();
-      const obj = { test: "value" };
+    it('should fail verification if object is modified after signing', () => {
+      const keypair = crypto.generateKeypair()
+      const obj = { test: 'value' }
 
-      crypto.signObj(obj, keypair.secretKey, keypair.publicKey);
-      obj.test = "modified";
+      crypto.signObj(obj, keypair.secretKey, keypair.publicKey)
+      obj.test = 'modified'
 
       // verifyObj returns false when verification fails, not throws
-      const verified = crypto.verifyObj(obj);
-      expect(verified).toBe(false);
-    });
-  });
-});
+      const verified = crypto.verifyObj(obj)
+      expect(verified).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Applied Prettier formatting to `index.js` for consistent code style.

- Added a Prettier configuration file for code formatting.

- Updated unit tests to align with new code style.

- Minor adjustments to `jest.config.js` and `test.js` for style consistency.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.js</strong><dd><code>Apply Prettier formatting to `index.js`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.js

<li>Applied Prettier formatting for consistent code style.<br> <li> Removed unnecessary line breaks in error messages.<br> <li> Adjusted function declarations for style consistency.


</details>


  </td>
  <td><a href="https://github.com/shardeum/lib-crypto-web/pull/9/files#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346">+23/-44</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jest.config.js</strong><dd><code>Add newline at end of `jest.config.js`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jest.config.js

- Added newline at end of file for consistency.


</details>


  </td>
  <td><a href="https://github.com/shardeum/lib-crypto-web/pull/9/files#diff-1e058ca1442e46581b13571fb8d261f9e1f5657e26c96634d4c1072f0f0347f1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test.js</strong><dd><code>Apply Prettier formatting to `test.js`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test.js

<li>Applied Prettier formatting for consistent code style.<br> <li> Adjusted async function call style.


</details>


  </td>
  <td><a href="https://github.com/shardeum/lib-crypto-web/pull/9/files#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prettier.config.js</strong><dd><code>Add Prettier configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

prettier.config.js

<li>Added Prettier configuration file.<br> <li> Set single quotes and trailing commas.<br> <li> Configured print width and semicolon usage.


</details>


  </td>
  <td><a href="https://github.com/shardeum/lib-crypto-web/pull/9/files#diff-e42472dd65561fe56344281078077fb924cddca92821eadfbc2318cca3f89c9a">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>crypto.test.js</strong><dd><code>Update unit tests with Prettier formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/unit/crypto.test.js

<li>Applied Prettier formatting to unit tests.<br> <li> Updated test strings to use single quotes.<br> <li> Removed semicolons for style consistency.


</details>


  </td>
  <td><a href="https://github.com/shardeum/lib-crypto-web/pull/9/files#diff-f7ed17680b91af4a49da1f945f564a61c53ef233f2557c73ac523be640ac395c">+179/-187</a></td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>